### PR TITLE
Selectable PCL-Version

### DIFF
--- a/rack/Kconfig
+++ b/rack/Kconfig
@@ -224,6 +224,11 @@ config RACK_EXT_PCLDIR
     default n
     depends on RACK_PCL_SUPPORT
 
+config RACK_PCL_VERSION_SUFFIX
+    string "Specify the used PCL's major version (only up to one decimal), e.g. 1.6"
+    depends on RACK_PCL_SUPPORT
+    default 1.6
+
 config RACK_PCLDIR
     string "pcl install directory"
     depends on RACK_EXT_PCLDIR

--- a/rack/configure.ac
+++ b/rack/configure.ac
@@ -1863,7 +1863,7 @@ if test x"${CONFIG_RACK_PCL_SUPPORT}" = x"y"; then
             FLANN_LDFLAGS="-L${CONFIG_RACK_LIRE_INSTALLDIR}/flann/lib"
             FLANN_LIBS="-lflann -lflann_cpp -lflann_cpp-gd"
 
-            PCL_CPPFLAGS="${FLANN_CPPFLAGS} ${BOOST_CPPFLAGS} ${EIGEN_CPPFLAGS} -I${CONFIG_RACK_PCLDIR}/include/pcl-1.6"
+            PCL_CPPFLAGS="${FLANN_CPPFLAGS} ${BOOST_CPPFLAGS} ${EIGEN_CPPFLAGS} -I${CONFIG_RACK_PCLDIR}/include/pcl-${CONFIG_RACK_PCL_VERSION_SUFFIX}"
             PCL_LDFLAGS="${BOOST_LDFLAGS} -L${CONFIG_RACK_PCLDIR}/lib -Wl,-rpath=${CONFIG_RACK_PCLDIR}/lib"
             PCL_LIBS="-lpcl_features -lpcl_filters -lpcl_io -lpcl_keypoints -lpcl_registration -lpcl_sample_consensus -lpcl_segmentation"
 


### PR DESCRIPTION
Files 'Kconfig' and 'configure.ac' updated: Allow setting of PCL-Version, formerly hard-coded to 1.6
