### PR TITLE
fix amobiguous abs(..) call in RackDataModule

### DIFF
--- a/rack/main/common/rack_data_module.cpp
+++ b/rack/main/common/rack_data_module.cpp
@@ -262,7 +262,11 @@ int         RackDataModule::getDataBufferIndex(rack_time_t time)
         {
             old_rectime = getRecordingTime(dataBuffer[old_index].pData);
 
-            timeDiff = abs(old_rectime - time);
+            // cast to int64_t to handle possible wrap around
+            // uint32_t difference was ambiguous for compiler
+            timeDiff = abs(static_cast<int64_t>(old_rectime)
+                           - static_cast<int64_t>(time));
+
             if (timeDiff <= minTimeDiff)
             {
                 minTimeDiff = timeDiff;


### PR DESCRIPTION
the time diff between two uint32 cause ambiguous call of abs cast to int64_t to avoid hypothetic wrap around
this causes additional processing power, because casting from 32 to 64 bit we do this, because abs() should handle signed values we need 64 bit to safely handle all possible uint32_t values because the result is in
[-UINT32MAX, ..., 2*UINT32MAX]